### PR TITLE
fix playlist generator

### DIFF
--- a/overrides.js
+++ b/overrides.js
@@ -1,0 +1,30 @@
+const overrides = {
+    denylist: {
+        tracks: [],
+        albums: [
+            "6AVhZFoVQNjVKTb2lVNokw",
+            "2T9jkpdjKDjzoOqPfaCAMu",
+            "1S7mumn7D4riEX2gVWYgPO",
+            "4AisqgQXW57ADDJRBQOpON",
+            "6FGyqglqi0oS3tl4SxyZxf",
+            "1a4SgsQYl2B2PmI5XffWW5",
+            "3wZTKnhwWhTW5EwfyGc4OT",
+            "7gKdoim3rYHoNGw4p71kJx"
+        ],
+        artists: [
+            "1V95p8oWGxXlpcFRYqXV3w",
+            "1XzY7sGHYarxdc9u2Ks1oU",
+            "6YYk2yfx7jUHLfI5W1sgNi",
+            "7oWSqrgMuIEyH9qp5nu2e5",
+            "0w5SU4gzff0dsC2aohgIzU",
+            "6nCO4Jv7mU99OS6jLevYVH",
+            "2I9JVgirByTBg7g4EHNQh5",
+            "6VF93ZcQqYC1kLJdcsmuex",
+            "2A3DK9TwLnlkjI5OMITTjQ",
+            "6ufVQnyyFBLj8YzcKG3OYl",
+            "6goK4KMSdP4A8lw8jk4ADk"
+        ]
+    }
+}
+
+module.exports ={overrides}

--- a/playlistGenerator.js
+++ b/playlistGenerator.js
@@ -1,7 +1,7 @@
 require('dotenv').config()
-var webapi = require('../clients/webapi.js');
-var accounts = require('../clients/accounts.js');
-const {overrides} = require('../overrides.js')
+var webapi = require('./spotify-clients/webapi.js')
+var accounts = require('./spotify-clients/accounts.js');
+const {overrides} = require('./overrides.js')
 
 const realPlaylistId = process.env.PLAYLISTID
 const testPlaylistId = process.env.TESTPLAYLISTID
@@ -144,7 +144,7 @@ async function getAllTracksAndCreatePlaylist() {
   // get tracks from last weeks playlist
   const playlistAuth = await accounts.getTokenFromRefreshToken(createPlaylistRefreshToken)
   const lastWeeksPlaylist = await webapi.getLastWeeksTracks(playlistAuth.access_token, realPlaylistId)
-  const lastWeeksTracks = createTrackListFromLastWeeksTracks(lastWeeksPlaylist)
+  const lastWeeksTracks = createTrackListFromLastWeeksTracks(JSON.parse(lastWeeksPlaylist).items)
 
   // determine user order to generate tracks
   let offset
@@ -172,7 +172,7 @@ async function getAllTracksAndCreatePlaylist() {
   for (i = 0; i < noOfUsers; i++) {
     var pointer = (i + offset) % noOfUsers;
     var userTopTracks = await webapi.getTopTracksforUser(userTokens[pointer])
-    var eligibleTracks = filterTopTracksForUser(userTopTracks, lastWeeksTracks, currentWeekTracks)
+    var eligibleTracks = filterTopTracksForUser(JSON.parse(userTopTracks).items, lastWeeksTracks, currentWeekTracks)
     currentWeekTracks = currentWeekTracks.concat(eligibleTracks)
   }
   

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const express = require('express');
 const session = require('express-session');
-const webapi = require('./spotify-clients/webapi.js');
-const accounts = require('./spotify-clients/accounts.js');
+const webapi = require('../spotify-clients/webapi.js');
+const accounts = require('../spotify-clients/accounts.js');
 const parseurl = require('parseurl');
 const querystring = require('querystring');
 

--- a/spotify-clients/accounts.js
+++ b/spotify-clients/accounts.js
@@ -46,7 +46,6 @@ module.exports = {
           console.error(err)
           reject(err)
         })
-
         req.write(postData)
         req.end()
       }

--- a/spotify-clients/webapi.js
+++ b/spotify-clients/webapi.js
@@ -26,7 +26,7 @@ module.exports = {
           })
 
           res.on('end', () => {
-            resolve(JSON.parse(data).items)
+            resolve(data)
           })
         })
         req.on('error', error => {
@@ -63,7 +63,7 @@ module.exports = {
             data = data + chunk
           })
           res.on('end', function() {
-            resolve(JSON.parse(data))
+            resolve(data)
           })
         })
 
@@ -101,7 +101,6 @@ module.exports = {
           })
 
           res.on('end', () => {
-            //resolve(JSON.parse(data).items)
             resolve(data)
           })
         })


### PR DESCRIPTION
add overrides file
fix spotify-clients return statements so they are used the same by the server and the playlist generator
re-organize: move PlaylistGenerator and spotify-clients out of server 